### PR TITLE
Implementation of tracking & transferring Discord guild ownership

### DIFF
--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,11 +1,11 @@
-arguments=--init-script /home/vscode/.vscode-remote/data/User/globalStorage/redhat.java/1.18.0/config_linux/org.eclipse.osgi/51/0/.cp/gradle/init/init.gradle --init-script /home/vscode/.vscode-remote/data/User/globalStorage/redhat.java/1.18.0/config_linux/org.eclipse.osgi/51/0/.cp/gradle/protobuf/init.gradle
+arguments=--init-script C\:\\Users\\Peter\\AppData\\Roaming\\Code\\User\\globalStorage\\redhat.java\\1.18.0\\config_win\\org.eclipse.osgi\\53\\0\\.cp\\gradle\\init\\init.gradle --init-script C\:\\Users\\Peter\\AppData\\Roaming\\Code\\User\\globalStorage\\redhat.java\\1.18.0\\config_win\\org.eclipse.osgi\\53\\0\\.cp\\gradle\\protobuf\\init.gradle
 auto.sync=false
 build.scans.enabled=false
 connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=/usr/local/sdkman/candidates/java/current
+java.home=C\:/Program Files/Eclipse Adoptium/jdk-17.0.7.7-hotspot
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,13 +1,11 @@
-arguments=--init-script C\:\\Users\\Peter\\AppData\\Roaming\\Code\\User\\globalStorage\\redhat.java\\1.18.0\\config_win\\org.eclipse.osgi\\53\\0\\.cp\\gradle\\init\\init.gradle --init-script C\:\\Users\\Peter\\AppData\\Roaming\\Code\\User\\globalStorage\\redhat.java\\1.18.0\\config_win\\org.eclipse.osgi\\53\\0\\.cp\\gradle\\protobuf\\init.gradle
+arguments=--init-script /home/vscode/.vscode-remote/data/User/globalStorage/redhat.java/1.18.0/config_linux/org.eclipse.osgi/51/0/.cp/gradle/init/init.gradle --init-script /home/vscode/.vscode-remote/data/User/globalStorage/redhat.java/1.18.0/config_linux/org.eclipse.osgi/51/0/.cp/gradle/protobuf/init.gradle
 auto.sync=false
 build.scans.enabled=false
 connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
 gradle.user.home=
-java.home=C\:/Program Files/Eclipse Adoptium/jdk-17.0.7.7-hotspot
+java.home=/usr/local/sdkman/candidates/java/current
 jvm.arguments=
 offline.mode=false
 override.workspace.settings=true
-show.console.view=true
-show.executions.view=true

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/CommandModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/CommandModule.java
@@ -44,7 +44,7 @@ public class CommandModule {
     public UpdateOwnerEventHandler provideUpdateOwnerEvent(UpdateOwnerEvent updateOwnerEvent) {
         return updateOwnerEvent;
     }
-    
+
     @Provides
     public RemoveMemberHandler provideRemoveMember(RemoveMemberEvent removeMember) {
         return removeMember;

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/CommandModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/CommandModule.java
@@ -12,6 +12,7 @@ import edu.northeastern.cs5500.starterbot.discord.events.LeaveGuildEvent;
 import edu.northeastern.cs5500.starterbot.discord.events.NewGuildJoinedEvent;
 import edu.northeastern.cs5500.starterbot.discord.events.NewMemberEvent;
 import edu.northeastern.cs5500.starterbot.discord.events.RemoveMemberEvent;
+import edu.northeastern.cs5500.starterbot.discord.events.UpdateOwnerEvent;
 import edu.northeastern.cs5500.starterbot.discord.handlers.ButtonHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.LeaveGuildEventHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.NewGuildJoinedHandler;
@@ -19,6 +20,7 @@ import edu.northeastern.cs5500.starterbot.discord.handlers.NewMemberHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.RemoveMemberHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.SlashCommandHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.StringSelectHandler;
+import edu.northeastern.cs5500.starterbot.discord.handlers.UpdateOwnerEventHandler;
 
 @Module
 public class CommandModule {
@@ -38,6 +40,11 @@ public class CommandModule {
         return guildLeaveEvent;
     }
 
+    @Provides
+    public UpdateOwnerEventHandler provideUpdateOwnerEvent(UpdateOwnerEvent updateOwnerEvent) {
+        return updateOwnerEvent;
+    }
+    
     @Provides
     public RemoveMemberHandler provideRemoveMember(RemoveMemberEvent removeMember) {
         return removeMember;

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
@@ -1,0 +1,38 @@
+package edu.northeastern.cs5500.starterbot.discord.events;
+
+import edu.northeastern.cs5500.starterbot.controller.GuildController;
+import edu.northeastern.cs5500.starterbot.controller.ListingController;
+import edu.northeastern.cs5500.starterbot.controller.UserController;
+import edu.northeastern.cs5500.starterbot.discord.handlers.UpdateOwnerEventHandler;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.events.guild.update.GuildUpdateOwnerEvent;
+
+@Singleton
+@Slf4j
+public class UpdateOwnerEvent implements UpdateOwnerEventHandler {
+
+    @Inject UserController userController;
+    @Inject ListingController listingController;
+    @Inject GuildController guildController;
+
+    @Inject
+    public UpdateOwnerEvent() {
+        // Defined public and empty for Dagger injection
+    }
+
+    @Override
+    @Nonnull
+    public String getName() {
+        return "updateowner";
+    }
+
+    @Override
+    public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event) {
+        log.info("event: updateowner");
+
+        
+    }
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
@@ -32,7 +32,7 @@ public class UpdateOwnerEvent implements UpdateOwnerEventHandler {
     @Override
     public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event) {
         log.info("event: updateowner");
-        
+
         guildController.setGuildOwnerId(event.getGuild().getId(), event.getNewOwnerId());
     }
 }

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/events/UpdateOwnerEvent.java
@@ -32,7 +32,7 @@ public class UpdateOwnerEvent implements UpdateOwnerEventHandler {
     @Override
     public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event) {
         log.info("event: updateowner");
-
         
+        guildController.setGuildOwnerId(event.getGuild().getId(), event.getNewOwnerId());
     }
 }

--- a/src/main/java/edu/northeastern/cs5500/starterbot/discord/handlers/UpdateOwnerEventHandler.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/discord/handlers/UpdateOwnerEventHandler.java
@@ -1,0 +1,22 @@
+package edu.northeastern.cs5500.starterbot.discord.handlers;
+
+import javax.annotation.Nonnull;
+import net.dv8tion.jda.api.events.guild.update.GuildUpdateOwnerEvent;
+
+public interface UpdateOwnerEventHandler {
+
+    /**
+     * Retrieves the name of the event when the guild owner is updated.
+     *
+     * @return The name of the event.
+     */
+    @Nonnull
+    public String getName();
+
+    /**
+     * Handles the event when the owner of the guild is updated.
+     *
+     * @param event - The JDA event where owner of the guild is updated.
+     */
+    public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event);
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/listener/MessageListener.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/listener/MessageListener.java
@@ -7,6 +7,7 @@ import edu.northeastern.cs5500.starterbot.discord.handlers.NewMemberHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.RemoveMemberHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.SlashCommandHandler;
 import edu.northeastern.cs5500.starterbot.discord.handlers.StringSelectHandler;
+import edu.northeastern.cs5500.starterbot.discord.handlers.UpdateOwnerEventHandler;
 import edu.northeastern.cs5500.starterbot.exceptions.GuildNotFoundException;
 import edu.northeastern.cs5500.starterbot.exceptions.GuildOwnerNotFoundException;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
+import net.dv8tion.jda.api.events.guild.update.GuildUpdateOwnerEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
@@ -37,6 +39,7 @@ public class MessageListener extends ListenerAdapter {
     @Inject NewGuildJoinedHandler newGuildJoined;
     @Inject RemoveMemberHandler removeMember;
     @Inject LeaveGuildEventHandler guildLeaveEvent;
+    @Inject UpdateOwnerEventHandler updateOwnerEvent;
 
     @Inject
     public MessageListener() {
@@ -123,6 +126,11 @@ public class MessageListener extends ListenerAdapter {
     @Override
     public void onGuildLeave(@Nonnull GuildLeaveEvent event) {
         guildLeaveEvent.onGuildLeaveEvent(event);
+    }
+
+    @Override
+    public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event) {
+        updateOwnerEvent.onGuildUpdateOwner(event);
     }
 
     @Override


### PR DESCRIPTION
Bot now tracks and updates the Guild owner ID when the ownership is transferred from one user to another. It is essential to track the current owner of the guild since the owner is the only user who can use commands with permission restrictions.